### PR TITLE
Change tag to playframework

### DIFF
--- a/activator.properties
+++ b/activator.properties
@@ -1,4 +1,4 @@
 name=macwire-activator
 title=No-framework Dependency Injection with MacWire and Play Activator
 description=This activator explains what Dependency Injection is and shows how to do DI in a Play application, with the help from a small library, MacWire. But without any additional frameworks! You will see how to divide the wiring of your classes into modules using traits, as well as how to use Scala Macros to remove some boilerplate code.
-tags=Basics,play,scala,dependency-injection,injection,macros
+tags=Basics,playframework,scala,dependency-injection,injection,macros


### PR DESCRIPTION
We want to use the Activator tag `playframework` for all Play related projects.
